### PR TITLE
Update application

### DIFF
--- a/net.sourceforge.xournal.json
+++ b/net.sourceforge.xournal.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.sourceforge.xournal",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "18.08",
+  "runtime-version": "19.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "xournal",
   "finish-args": [
@@ -11,6 +11,7 @@
   ],
   "modules": [
     "shared-modules/gtk2/gtk2.json",
+    "shared-modules/intltool/intltool-0.51.json",
     {
       "name": "libart",
       "rm-configure": true,

--- a/net.sourceforge.xournal.json
+++ b/net.sourceforge.xournal.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.sourceforge.xournal",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "19.08",
+  "runtime-version": "20.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "xournal",
   "finish-args": [

--- a/net.sourceforge.xournal.json
+++ b/net.sourceforge.xournal.json
@@ -81,8 +81,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://poppler.freedesktop.org/poppler-0.77.0.tar.xz",
-          "sha256": "7267eb4cbccd64a58244b8211603c1c1b6bf32c7f6a4ced2642865346102f36b"
+          "url": "https://poppler.freedesktop.org/poppler-21.02.0.tar.xz",
+          "sha256": "5c14759c99891e6e472aced6d5f0ff1dacf85d80cd9026d365c55c653edf792c"
         }
       ]
     },


### PR DESCRIPTION
Hey, I've taken the effort of updating this package, although I'm critical about it as a whole. Xournal++ Is actively maintained, while this application is from 2016.

As such, I propose two plans:
1. Merge my contributions, updating the app so it keeps functioning as-is
2. Deprecate the app and migrate all users to `com.github.xournalpp.xournalpp`

@TingPing pinging you since nobody else seems to supervise this application.